### PR TITLE
Fixed the size of the Boulder point structure

### DIFF
--- a/DelveDestroyer/MainEntry.cpp
+++ b/DelveDestroyer/MainEntry.cpp
@@ -55,7 +55,7 @@ struct Boulders
 {
 	bool active = false;
 	double pos[1];
-	GLfloat Point[8][1];
+	GLfloat Point[8][2];
 	double speed;
 };
 


### PR DESCRIPTION
Please don't use raw arrays, if you're not making use of `glVertex**v` functions. If you want to store coordinates, create proper structures for them.